### PR TITLE
Fix acpid.service startup failure

### DIFF
--- a/acpid/install.sh
+++ b/acpid/install.sh
@@ -39,9 +39,9 @@ if [ "${1}" = "late" ]; then
     echo "Restart=always"                        >>${DEST}
     echo "RestartSec=30"                         >>${DEST}
     echo "PIDFile=/var/run/acpid.pid"            >>${DEST}
-    echo "ExecStartPre=/sbin/modprobe button"    >>${DEST}
+    echo "ExecStartPre=-/sbin/modprobe button"    >>${DEST}
     echo "ExecStart=/usr/sbin/acpid -f"          >>${DEST}
-    echo "ExecStopPost=/sbin/modprobe -r button" >>${DEST}
+    echo "ExecStopPost=-/sbin/modprobe -r button" >>${DEST}
     echo                                         >>${DEST}
     echo "[X-Synology]"                          >>${DEST}
     echo "Author=Virtualization Team"            >>${DEST}


### PR DESCRIPTION
```
N5105
PVE8
SA6400
DSM 7.2.1 update1
rr，addon，modules均为最新
```
acpid.service启动失败，原因是`/lib/modules`下不存在`button.ko`导致`ExecStartPre=/sbin/modprobe button`执行失败，服务每隔30秒重启一次
通过`lsmod`发现`button`是已经加载了的，直接`ExecStart`就行

发现在rr的addon中取消acpid的选择是保存不了的，每次进rr的config都会自动选上

还发现`/dev/input/event*`不存在，`acpid.service`还是会启动失败，内核没开`CONFIG_INPUT_EVDEV`？