### PR TITLE
Fix acpid.service startup failure again

### DIFF
--- a/acpid/install.sh
+++ b/acpid/install.sh
@@ -35,11 +35,9 @@ if [ "${1}" = "late" ]; then
     echo "After=multi-user.target"               >>${DEST}
     echo                                         >>${DEST}
     echo "[Service]"                             >>${DEST}
-    echo "Type=forking"                          >>${DEST}
     echo "Restart=always"                        >>${DEST}
     echo "RestartSec=30"                         >>${DEST}
-    echo "PIDFile=/var/run/acpid.pid"            >>${DEST}
-    echo "ExecStartPre=-/sbin/modprobe button"    >>${DEST}
+    echo "ExecStartPre=-/sbin/modprobe button"   >>${DEST}
     echo "ExecStart=/usr/sbin/acpid -f"          >>${DEST}
     echo "ExecStopPost=-/sbin/modprobe -r button" >>${DEST}
     echo                                         >>${DEST}


### PR DESCRIPTION
evdev.ko没有问题，但是`acpid`在`-f`运行时不会生成`acpid.pid`文件，导致`service`持续`restart`
直接`simple`运行就行